### PR TITLE
Release version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## [0.0.4] - 2015-09-14
-- added metrics
+## [0.1.0] - 2016-08-18
+### Changed
+- Updated sensu-plugin dependency from `= 1.2.0` to `~> 1.2.0`
+
+### Added
+- metrics-kannel.rb: new metric plugin added!
+- check-kannel.rb: new option for specifying pattern to match SMSC id
 
 ## [0.0.3] - 2015-07-14
 ### Changed
@@ -22,7 +27,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-kannel/compare/0.0.4...HEAD
-[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-kannel/compare/0.0.3...0.0.4
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-kannel/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/sensu-plugins/sensu-plugins-kannel/compare/0.0.3...0.1.0
 [0.0.3]: https://github.com/sensu-plugins/sensu-plugins-kannel/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/sensu-plugins/sensu-plugins-kannel/compare/0.0.1...0.0.2

--- a/lib/sensu-plugins-kannel/version.rb
+++ b/lib/sensu-plugins-kannel/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsKannel
   module Version
     MAJOR = 0
-    MINOR = 0
-    PATCH = 3
+    MINOR = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

Does not relate to an existing issue. Changelog was updated detailing a 0.0.4 release which was never tagged. Suggesting we release as 0.1.0 here, given that we've added two new features (a new plugin and a new flag for an existing plugin) in this release.
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Publish changes already merged to master in a new version!
#### Known Compatibility Issues

None known.
